### PR TITLE
Emulate Kobo's epub2 processing of the body tag

### DIFF
--- a/common.py
+++ b/common.py
@@ -104,6 +104,8 @@ def modify_epub(container, filename, metadata=None, opts={}):
             print("KoboTouchExtended:common:modify_epub:Adding extended Kobo features to {0} by {1}".format(metadata.title, ' and '.join(metadata.authors)))
         # Add the Kobo span tags
         container.add_kobo_spans()
+        # Add the Kobo style hacks div tags
+        container.add_kobo_divs()
 
         skip_js = False
         # Check to see if there's already a kobo*.js in the ePub
@@ -119,5 +121,12 @@ def modify_epub(container, filename, metadata=None, opts={}):
                         jsname = container.copy_file_to_container(os.path.join(reference_container.root, name), name='kobo.js')
                         container.add_content_file_reference(jsname)
                         break
+
+        # Add the Kobo style hacks
+        stylehacks_css = PersistentTemporaryFile(suffix='_stylehacks', prefix='kepub_')
+        stylehacks_css.write(get_resources('css/style-hacks.css'))
+        stylehacks_css.close()
+        css_path = os.path.basename(container.copy_file_to_container(stylehacks_css.name, name='kte-css/stylehacks.css'))
+        container.add_content_file_reference("kte-css/{0}".format(css_path))
     os.unlink(filename)
     container.commit(filename)

--- a/css/style-hacks.css
+++ b/css/style-hacks.css
@@ -1,0 +1,14 @@
+div#book-inner p, div#book-inner div {
+	font-size: 1.0em;
+}
+a {
+	color: black;
+}
+a:link, a:visited, a:hover, a:active {
+	color: blue;
+}
+div#book-inner * {
+	margin-top: 0 !important;
+	margin-bottom: 0 !important;
+}
+


### PR DESCRIPTION
Wrap its content in dual divs, book-inner & book-columns, like they do
for epub2 files.
Add the accompanying styling hacks.

This helps the kepub cut-off bug workaround patch to do its
job by making sideloaded files more closely match synced ones.

Note that I implemented a crappy heuristic disabling these divs on
books that appear to use div tags to handle paragraphs, because I found
that this appeared to break styling in fun and interesting ways, but
couldn't find anything wrong with the files. I'm far from a
CSS/HTML/Kobo expert, so feel free to join in if you have an idea :).

----

cf. http://www.mobileread.com/forums/showpost.php?p=3021871&postcount=1137

Part 2 of 2.