### PR TITLE
Don't strip whitespace from text when adding kobo spans

### DIFF
--- a/container.py
+++ b/container.py
@@ -540,7 +540,7 @@ class KEPubContainer(EpubContainer):
         # split text in sentences
         groups = TEXT_SPLIT_RE.split(text)
         # remove empty strings resulting from split()
-        groups = [g.lstrip() for g in groups if g.strip() != ""]
+        groups = [g for g in groups if g.strip() != ""]
         for idx in range(len(groups)):
             if hasattr(groups[idx], "decode"):
                 groups[idx] = groups[idx].decode("UTF-8")


### PR DESCRIPTION
This fixes the problem reported on MR with missing spaces after spans in the original epub. But, it affects any tag, not just the spans. And it was also removing any whitespace at the start of text. At the start of a paragraph, that might be OK, but, it isn't elsewhere, or if non-breaking spaces are used.