### PR TITLE
Update error messages for failed conversions

### DIFF
--- a/device/driver.py
+++ b/device/driver.py
@@ -15,6 +15,7 @@ import json
 import os
 import re
 import shutil
+import sys
 from datetime import datetime
 
 from calibre.constants import config_dir
@@ -284,14 +285,19 @@ class KOBOTOUCHEXTENDED(KOBOTOUCH):
                 },
             )
         except Exception as e:
-            common.log.exception(
-                "Failed to process {0} by {1}: {2}".format(
-                    metadata.title, " and ".join(metadata.authors), str(e),
-                )
+            msg = "Failed to process {title} by {authors}: {msg}".format(
+                title=metadata.title,
+                authors=" and ".join(metadata.authors),
+                msg=str(e),
             )
+            common.log.exception(msg)
 
             if not skip_failed:
-                raise
+                tb = sys.exc_info()[2]
+                if is_py3:
+                    raise e.__class__(msg).with_traceback(tb)
+                else:
+                    exec("raise e.__class__(msg), None, tb")
 
             self.skip_renaming_files.add(metadata.uuid)
             return super(KOBOTOUCHEXTENDED, self)._modify_epub(

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -3,7 +3,7 @@
 # This is needed to force shellcheck to actually run, and bash and zsh are
 # typically close enough that it shouldn't cause a problem.
 
-set -eu
+set -eux
 
 if [ -x /usr/bin/uname ]; then
 	UNAME_BIN="/usr/bin/uname"

--- a/scripts/update-calibre.py
+++ b/scripts/update-calibre.py
@@ -102,6 +102,8 @@ def get_calibre_py2() -> None:
             f"Github API request returned HTTP{api_resp.status} {api_resp.reason}"
         )
 
+    log(f"Got HTTP{api_resp.status} {api_resp.reason} from Github API")
+
     release_data = json.load(api_resp)
     log("Loaded Github release data")
 
@@ -190,7 +192,7 @@ if __name__ == "__main__":
         "version",
         type=str,
         default=None,
-        nargs='?',
+        nargs="?",
         help="A single Python version to target (default: both 2.7 and 3.x)",
     )
     opts = parser.parse_args()

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -8,9 +8,12 @@ from __future__ import unicode_literals
 # anything from calibre or the plugins yet.
 import glob
 import os
+import shutil
 import sys
+import tempfile
 import unittest
 import uuid
+import warnings
 
 test_dir = os.path.dirname(os.path.abspath(__file__))
 src_dir = os.path.dirname(test_dir)
@@ -25,6 +28,7 @@ except ImportError:
     # Python 2
     import mock
 
+from calibre_plugins.kobotouch_extended import container
 from calibre_plugins.kobotouch_extended.device import driver
 
 
@@ -38,7 +42,23 @@ class MockPropertyFalse:
         return False
 
 
+class MockKePubContainer(mock.MagicMock):
+    def is_drm_encumbered(self):
+        return False
+
+
 class DeviceTestBase(unittest.TestCase):
+    log = mock.Mock()
+
+    def __init__(self, *args, **kwargs):
+        super(DeviceTestBase, self).__init__(*args, **kwargs)
+        self.reference_book = os.path.join(test_dir, "reference_book")
+
+        self.mi = mock.MagicMock()
+        self.mi.title = "Test Book"
+        self.mi.authors = ["John Q. Public", "Suzie Q. Public"]
+        self.mi.uuid = uuid.uuid4()
+
     @classmethod
     def setUpClass(cls):
         driver.common.log = mock.MagicMock()
@@ -49,10 +69,30 @@ class DeviceTestBase(unittest.TestCase):
         )
         self.device.startup()
         self.device.initialize()
+        self.device._main_prefix = "/mnt/kobo"
+
+        self.basedir = tempfile.mkdtemp(prefix="kte-", suffix="-test", dir=test_dir)
+        self.epub_dir = os.path.join(self.basedir, "kepub")
+        self.tmpdir = os.path.join(self.basedir, "tmp")
+
+        shutil.copytree(self.reference_book, self.epub_dir)
+        os.mkdir(self.tmpdir)
+
+        self.container = container.KEPubContainer(
+            self.epub_dir, self.log, tdir=self.tmpdir
+        )
+
+        if sys.version_info >= (3, 2):
+            warnings.simplefilter("ignore", category=ResourceWarning)
 
     def tearDown(self):
         self.device.shutdown()
         self.device = None
+
+        self.log.reset_mock()
+
+        if self.basedir and os.path.isdir(self.basedir):
+            shutil.rmtree(self.basedir, ignore_errors=True)
 
 
 @mock.patch.object(driver.KOBOTOUCHEXTENDED, "extra_features", True)
@@ -95,6 +135,17 @@ class TestDeviceWithExtendedFeatures(DeviceTestBase):
         sanitized_components = self.device.sanitize_path_components(test_components)
         self.assertListEqual(sanitized_components, expected_components)
 
+    @mock.patch.object(
+        driver.common, "modify_epub", side_effect=ValueError("Testing exception")
+    )
+    def test_modify_epub_exception_fails(self, _modify_epub):
+        self.assertFalse(self.device.skip_failed)
+
+        with self.assertRaises(ValueError):
+            self.device._modify_epub("test.epub", self.mi, self.container)
+
+        self.assertNotIn(self.mi.uuid, self.device.skip_renaming_files)
+
 
 @mock.patch.object(driver.KOBOTOUCHEXTENDED, "extra_features", False)
 class TestDeviceWithoutExtendedFeatures(DeviceTestBase):
@@ -106,6 +157,23 @@ class TestDeviceWithoutExtendedFeatures(DeviceTestBase):
         for ext in ("kepub", "epub", "mobi"):
             cb_name = self.device.filename_callback("reference.{0}".format(ext), mi)
             self.assertEqual(cb_name, "reference.{0}".format(ext))
+
+
+@mock.patch.object(driver.KOBOTOUCHEXTENDED, "extra_features", True)
+@mock.patch.object(driver.KOBOTOUCHEXTENDED, "skip_failed", True)
+class TestDeviceSkippingErrors(DeviceTestBase):
+    @mock.patch.object(
+        driver.common, "modify_epub", side_effect=ValueError("Testing exception")
+    )
+    @mock.patch.object(driver.KOBOTOUCH, "_modify_epub")
+    def test_modify_epub_skip_exceptions(
+        self, _extended_modify_epub, _base_modify_epub
+    ):
+        self.assertTrue(self.device.skip_failed)
+
+        self.device._modify_epub("test.epub", self.mi, self.container)
+
+        self.assertIn(self.mi.uuid, self.device.skip_renaming_files)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Pull Request: Update failed conversion error message

## Description of change

This updates the error message displayed when a book fails conversion and failures are not skipped. The updated error message now states which book failed.

## Test results

See CI results: tests pass, except for macOS Python 3. This is expected, there is an issue with `calibre-customize` which is causing it to repeatedly fail to execute on macOS under Python 3.
