### PR TITLE
Update tags skipped for Kobo span processing

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -38,6 +38,6 @@ jobs:
       - uses: actions/checkout@v2.2.0
 
       - name: yamllint
-        uses: nosborn/github-action-yamllint@v1
+        uses: jgoguen/gh-actions/yaml-lint@main
         with:
-          files_or_dir: ./.github/workflows/
+          source: ./.github/workflows/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,5 @@
 	"python.autoComplete.extraPaths": [
 		"${workspaceFolder:calibre}/src"
 	],
-	"python.formatting.blackPath": "/usr/bin/black",
 	"python.pythonPath": "/usr/bin/python2"
 }

--- a/container.py
+++ b/container.py
@@ -57,7 +57,24 @@ ENCRYPTION_NAMESPACES = {
     "deenc": "http://ns.adobe.com/digitaleditions/enc",
 }  # type: Dict[str, str]
 XHTML_NAMESPACE = "http://www.w3.org/1999/xhtml"  # type: str
-SPECIAL_TAGS = frozenset(["img"])  # type: Set[str]
+SPECIAL_TAGS = frozenset(
+    [
+        "button",
+        "circle",
+        "defs",
+        "figcaption",
+        "figure",
+        "g",
+        "img",
+        "input",
+        "path",
+        "polygon",
+        "rect",
+        "style",
+        "svg",
+        "use",
+    ]
+)  # type: Set[str]
 ENCODING_RE = re.compile(r'^\<\?.+encoding="([^"]+)"', re.MULTILINE)
 SELF_CLOSING_RE = re.compile(
     r"<(meta|link) ([^>]+)>.*?</\1>", re.UNICODE | re.MULTILINE


### PR DESCRIPTION
# Pull Request: Update tags skipped for Kobo span processing

## Description of change

Update the list of HTML tags which will be skipped when applying Kobo spans. Normally all children are considered, but for tags in the updated list they're wrapped in a span and returned.

Fixes #120

## Test results

CI fails on macOS for Python 3, but unfortunately that's currently expected due to `calibre-customize`.