### PR TITLE
Add template for deciding if to kepubify

### DIFF
--- a/device/koboextended_config.py
+++ b/device/koboextended_config.py
@@ -8,6 +8,7 @@ __copyright__ = "2016, David Forrester, Joel Goguen <contact@jgoguen.ca>"
 __docformat__ = "markdown en"
 
 import functools
+import textwrap
 
 from PyQt5.Qt import QGridLayout
 from PyQt5.Qt import QLabel
@@ -15,7 +16,7 @@ from PyQt5.Qt import QLineEdit
 from PyQt5.Qt import QSpinBox
 from PyQt5.Qt import QVBoxLayout
 
-from calibre.devices.kobo.kobotouch_config import KOBOTOUCHConfig
+from calibre.devices.kobo.kobotouch_config import KOBOTOUCHConfig, TemplateConfig
 from calibre.gui2.device_drivers.tabbed_device_config import DeviceConfigTab
 from calibre.gui2.device_drivers.tabbed_device_config import DeviceOptionsGroupBox
 from calibre.gui2.device_drivers.tabbed_device_config import create_checkbox
@@ -27,6 +28,9 @@ try:
     load_translations()
 except NameError:
     pass
+
+def wrap_msg(msg):
+    return textwrap.fill(msg.strip(), 100)
 
 
 class KOBOTOUCHEXTENDEDConfig(KOBOTOUCHConfig):
@@ -65,7 +69,11 @@ class KOBOTOUCHEXTENDEDConfig(KOBOTOUCHConfig):
         common.log.debug("KOBOTOUCHEXTENDEDConfig::commit: start")
         p = super(KOBOTOUCHEXTENDEDConfig, self).commit()
 
+        self.tabExtended.use_template
+        self.tabExtended.kepubify_template
         p["extra_features"] = self.extra_features
+        p["use_template"] = self.use_template
+        p["kepubify_template"] = self.kepubify_template
         p["upload_encumbered"] = self.upload_encumbered
         p["skip_failed"] = self.skip_failed
         p["hyphenate"] = self.hyphenate
@@ -92,9 +100,15 @@ class TabExtendedConfig(DeviceConfigTab):
         self.l = QVBoxLayout(self)  # noqa: E741
         self.setLayout(self.l)
 
+        self.kepubify_options = KepubifyGroupBox(self, device)
+        self.l.addWidget(self.kepubify_options)
+        self.addDeviceWidget(self.kepubify_options)
         self.extended_options = ExtendedGroupBox(self, device)
         self.l.addWidget(self.extended_options)
         self.addDeviceWidget(self.extended_options)
+        self.hyphenation_options = HyphenationGroupBox(self, device)
+        self.l.addWidget(self.hyphenation_options)
+        self.addDeviceWidget(self.hyphenation_options)
 
 
 class ExtendedGroupBox(DeviceOptionsGroupBox):
@@ -103,18 +117,116 @@ class ExtendedGroupBox(DeviceOptionsGroupBox):
     def __init__(self, parent, device):
         """Set up driver config options group."""
         super(ExtendedGroupBox, self).__init__(
-            parent, device, _("Extended driver")  # noqa: F821
+            parent, device, _("Other options")  # noqa: F821
         )
 
         self.options_layout = QGridLayout()
         self.options_layout.setObjectName("options_layout")
         self.setLayout(self.options_layout)
 
-        self.extra_features_checkbox = create_checkbox(
-            _("Enable Extended Kobo Features"),  # noqa: F821
-            _("Choose whether to enable extra customizations"),  # noqa: F821
-            device.get_pref("extra_features"),
+        self.smarten_punctuation_checkbox = create_checkbox(
+            _("Smarten Punctuation"),  # noqa: F821
+            _("Select this to smarten punctuation in the ePub"),  # noqa: F821
+            device.get_pref("smarten_punctuation"),
         )
+
+        self.clean_markup_checkbox = create_checkbox(
+            _("Clean up ePub Markup"),  # noqa: F821
+            _("Select this to clean up the internal ePub markup."),  # noqa: F821
+            device.get_pref("clean_markup"),
+        )
+
+        self.full_page_numbers_checkbox = create_checkbox(
+            _("Use full book page numbers"),  # noqa: F821
+            _(  # noqa: F821
+                "Select this to show page numbers for the whole book, instead "
+                + "of each chapter. This will also affect regular ePub page "
+                + "number display! "
+                + "This is only useful for firmware before 3.11.0."
+            ),
+            device.get_pref("full_page_numbers"),
+        )
+
+        layout_line = 0
+        layout_line += 1
+        self.options_layout.addWidget(self.clean_markup_checkbox, layout_line, 0, 1, 1)
+        self.options_layout.addWidget(self.smarten_punctuation_checkbox, layout_line, 1, 1, 1)
+        layout_line += 1
+        self.options_layout.addWidget(self.full_page_numbers_checkbox, layout_line, 0, 1, 1)
+        layout_line += 1
+        self.options_layout.setRowStretch(layout_line, 2)
+
+    @property
+    def hyphenate(self):
+        """Determine if hyphenation should be enabled."""
+        return self.hyphenate_checkbox.isChecked()
+
+    @property
+    def smarten_punctuation(self):
+        """Determine if punctuation should be converted to smart punctuation."""
+        return self.smarten_punctuation_checkbox.isChecked()
+
+    @property
+    def clean_markup(self):
+        """Determine if additional markup cleanup will be done."""
+        return self.clean_markup_checkbox.isChecked()
+
+    @property
+    def full_page_numbers(self):
+        """Determine if full-book page numbers will be displayed."""
+        return self.full_page_numbers_checkbox.isChecked()
+
+    @property
+    def disable_hyphenation(self):
+        """Determine if hyphenation should be disabled."""
+        return self.disable_hyphenation_checkbox.isChecked()
+
+    @property
+    def hyphenate_chars(self):
+        return self.opt_kepub_hyphenate_chars.value()
+
+    @property
+    def hyphenate_chars_before(self):
+        return self.opt_kepub_hyphenate_chars_before.value()
+
+    @property
+    def hyphenate_chars_after(self):
+        return self.opt_kepub_hyphenate_chars_after.value()
+
+    @property
+    def hyphenate_limit_lines(self):
+        return self.opt_kepub_hyphenate_limit_lines.value()
+
+
+class KepubifyGroupBox(DeviceOptionsGroupBox):
+
+    def __init__(self, parent, device):
+        super(KepubifyGroupBox, self).__init__(parent, device)
+        self.setTitle(_("Send books as kepubs"))
+
+        self.options_layout = QGridLayout()
+        self.options_layout.setObjectName("options_layout")
+        self.setLayout(self.options_layout)
+
+        self.setCheckable(True)
+        self.setChecked(device.get_pref('extra_features'))
+        self.setToolTip(wrap_msg(_('Enable options to transform books to kepubs when sending them to the device.')))
+
+        self.use_template_checkbox = create_checkbox(
+            _("Use template for kepubification"),  # noqa: F821
+            _("Use a template to decide if books should be kepubified. If result is false or blank, it will not be kepubified."),  # noqa: F821
+            device.get_pref("use_template"),
+        )
+        self.kepubify_template_edit = TemplateConfig(
+                            device.get_pref('kepubify_template'),
+                            tooltip=_(  # noqa: F821
+                                "Enter a template to decide if a book is to be kepubified. "
+                                + "If the template returns false or true, the book will not be kepubified "
+                                + "and not other modifications will be made to the book."
+            )
+        )
+        self.use_template_checkbox.clicked.connect(self.use_template_checkbox_clicked)
+        self.use_template_checkbox_clicked(device.get_pref('use_template'))
 
         self.upload_encumbered_checkbox = create_checkbox(
             _("Upload DRM-encumbered ePub files"),  # noqa: F821
@@ -135,29 +247,6 @@ class ExtendedGroupBox(DeviceOptionsGroupBox):
                 + "failed books will be silently removed from the upload queue."
             ),
             device.get_pref("skip_failed"),
-        )
-
-        self.hyphenate_checkbox = create_checkbox(
-            _("Hyphenate Files"),  # noqa: F821
-            _(  # noqa: F821
-                "Select this to add a CSS file which enables hyphenation. The "
-                + "language used will be the language defined for the book in "
-                + "calibre. Please see the README file for directions on "
-                + "updating hyphenation dictionaries."
-            ),
-            device.get_pref("hyphenate"),
-        )
-
-        self.smarten_punctuation_checkbox = create_checkbox(
-            _("Smarten Punctuation"),  # noqa: F821
-            _("Select this to smarten punctuation in the ePub"),  # noqa: F821
-            device.get_pref("smarten_punctuation"),
-        )
-
-        self.clean_markup_checkbox = create_checkbox(
-            _("Clean up ePub Markup"),  # noqa: F821
-            _("Select this to clean up the internal ePub markup."),  # noqa: F821
-            device.get_pref("clean_markup"),
         )
 
         self.file_copy_dir_checkbox = create_checkbox(
@@ -181,14 +270,75 @@ class ExtendedGroupBox(DeviceOptionsGroupBox):
         self.file_copy_dir_edit.setText(device.get_pref("file_copy_dir"))
         self.file_copy_dir_label.setBuddy(self.file_copy_dir_edit)
 
-        self.full_page_numbers_checkbox = create_checkbox(
-            _("Use full book page numbers"),  # noqa: F821
+        layout_line = 0
+        self.options_layout.addWidget(self.use_template_checkbox, layout_line, 0, 1, 1)
+        self.options_layout.addWidget(self.kepubify_template_edit, layout_line, 1, 1, 1)
+        layout_line += 1
+        self.options_layout.addWidget(self.skip_failed_checkbox, layout_line, 0, 1, 1)
+        self.options_layout.addWidget(self.upload_encumbered_checkbox, layout_line, 1, 1, 1)
+        layout_line += 1
+        self.options_layout.addWidget(self.file_copy_dir_label, layout_line, 0, 1, 1)
+        self.options_layout.addWidget(self.file_copy_dir_edit, layout_line, 1, 1, 1)
+        # self.options_layout.setColumnStretch(0, 0)
+        # self.options_layout.setColumnStretch(1, 0)
+        # self.options_layout.setColumnStretch(2, 1)
+
+    def use_template_checkbox_clicked(self, checked):
+        self.kepubify_template_edit.setEnabled(checked)
+
+    @property
+    def extra_features(self):
+        """Determine if Kobo extra features are enabled."""
+        return self.isChecked()
+
+    @property
+    def use_template(self):
+        """Determine if the option to use the template for kepubification ."""
+        return self.use_template_checkbox.isChecked()
+
+    @property
+    def kepubify_template(self):
+        """Determine the kepubify template."""
+        return self.kepubify_template_edit.template
+
+    @property
+    def upload_encumbered(self):
+        """Determine if DRM-encumbered files will be uploaded."""
+        return self.upload_encumbered_checkbox.isChecked()
+
+    @property
+    def skip_failed(self):
+        """Determine if failed conversions will be skipped."""
+        return self.skip_failed_checkbox.isChecked()
+
+    @property
+    def file_copy_dir(self):
+        """Determine where to copy converted KePub books to."""
+        return self.file_copy_dir_edit.text().strip()
+
+
+class HyphenationGroupBox(DeviceOptionsGroupBox):
+    """The Hyphenation options group for KoboTouchExtended."""
+
+    def __init__(self, parent, device):
+        """Set up driver config options group."""
+        super(HyphenationGroupBox, self).__init__(
+            parent, device, _("Hyphenation")  # noqa: F821
+        )
+
+        self.options_layout = QGridLayout()
+        self.options_layout.setObjectName("options_layout")
+        self.setLayout(self.options_layout)
+
+        self.hyphenate_checkbox = create_checkbox(
+            _("Hyphenate Files"),  # noqa: F821
             _(  # noqa: F821
-                "Select this to show page numbers for the whole book, instead "
-                + "of each chapter. This will also affect regular ePub page "
-                + "number display!"
+                "Select this to add a CSS file which enables hyphenation. The "
+                + "language used will be the language defined for the book in "
+                + "calibre. Please see the README file for directions on "
+                + "updating hyphenation dictionaries."
             ),
-            device.get_pref("full_page_numbers"),
+            device.get_pref("hyphenate"),
         )
 
         self.disable_hyphenation_checkbox = create_checkbox(
@@ -289,46 +439,58 @@ class ExtendedGroupBox(DeviceOptionsGroupBox):
             device.get_pref("hyphenate_limit_lines")
         )
 
-        self.options_layout.addWidget(self.extra_features_checkbox, 0, 0, 1, 1)
-        self.options_layout.addWidget(self.upload_encumbered_checkbox, 0, 1, 1, 1)
-        self.options_layout.addWidget(self.skip_failed_checkbox, 1, 0, 1, 1)
-        self.options_layout.addWidget(self.hyphenate_checkbox, 1, 1, 1, 1)
-        self.options_layout.addWidget(self.smarten_punctuation_checkbox, 2, 1, 1, 1)
-        self.options_layout.addWidget(self.clean_markup_checkbox, 3, 0, 1, 1)
-        self.options_layout.addWidget(self.file_copy_dir_label, 4, 0, 1, 1)
-        self.options_layout.addWidget(self.file_copy_dir_edit, 4, 1, 1, 1)
-        self.options_layout.addWidget(self.full_page_numbers_checkbox, 5, 0, 1, 1)
-        self.options_layout.addWidget(self.disable_hyphenation_checkbox, 5, 1, 1, 1)
-        self.options_layout.addWidget(self.opt_kepub_hyphenate_chars_label, 6, 0, 1, 1)
-        self.options_layout.addWidget(self.opt_kepub_hyphenate_chars, 6, 1, 1, 1)
+        layout_line = 0
+        layout_line += 1
+        self.options_layout.addWidget(self.hyphenate_checkbox, layout_line, 0, 1, 1)
+        self.options_layout.addWidget(self.disable_hyphenation_checkbox, layout_line, 1, 1, 1)
+        layout_line += 1
+        self.options_layout.addWidget(self.opt_kepub_hyphenate_chars_label, layout_line, 0, 1, 1)
+        self.options_layout.addWidget(self.opt_kepub_hyphenate_chars, layout_line, 1, 1, 1)
+        layout_line += 1
         self.options_layout.addWidget(
-            self.opt_kepub_hyphenate_chars_before_label, 7, 0, 1, 1
+            self.opt_kepub_hyphenate_chars_before_label, layout_line, 0, 1, 1
         )
-        self.options_layout.addWidget(self.opt_kepub_hyphenate_chars_before, 7, 1, 1, 1)
+        self.options_layout.addWidget(self.opt_kepub_hyphenate_chars_before, layout_line, 1, 1, 1)
+        layout_line += 1
         self.options_layout.addWidget(
-            self.opt_kepub_hyphenate_chars_after_label, 8, 0, 1, 1
+            self.opt_kepub_hyphenate_chars_after_label, layout_line, 0, 1, 1
         )
-        self.options_layout.addWidget(self.opt_kepub_hyphenate_chars_after, 8, 1, 1, 1)
+        self.options_layout.addWidget(self.opt_kepub_hyphenate_chars_after, layout_line, 1, 1, 1)
+        layout_line += 1
         self.options_layout.addWidget(
-            self.opt_kepub_hyphenate_limit_lines_label, 9, 0, 1, 1
+            self.opt_kepub_hyphenate_limit_lines_label, layout_line, 0, 1, 1
         )
-        self.options_layout.addWidget(self.opt_kepub_hyphenate_limit_lines, 9, 1, 1, 1)
-        self.options_layout.setRowStretch(10, 2)
+        self.options_layout.addWidget(self.opt_kepub_hyphenate_limit_lines, layout_line, 1, 1, 1)
+        layout_line += 1
+        self.options_layout.setRowStretch(layout_line, 2)
 
-    @property
-    def extra_features(self):
-        """Determine if Kobo extra features are enabled."""
-        return self.extra_features_checkbox.isChecked()
+        self.disable_hyphenation_checkbox.clicked.connect(self.disable_hyphenation_checkbox_clicked)
+        self.hyphenate_checkbox.clicked.connect(self.hyphenate_checkbox_clicked)
+        self.disable_hyphenation_checkbox_clicked(device.get_pref("disable_hyphenation"))
+        self.hyphenate_checkbox_clicked(device.get_pref("hyphenate"))
 
-    @property
-    def upload_encumbered(self):
-        """Determine if DRM-encumbered files will be uploaded."""
-        return self.upload_encumbered_checkbox.isChecked()
 
-    @property
-    def skip_failed(self):
-        """Determine if failed conversions will be skipped."""
-        return self.skip_failed_checkbox.isChecked()
+    def disable_hyphenation_checkbox_clicked(self, checked):
+        enable_hyphenation_fields = not (checked or self.disable_hyphenation_checkbox.isChecked())
+        self.toggle_hyphenation_fields(enable_hyphenation_fields)
+        if self.hyphenate_checkbox.isChecked() and checked:
+            self.hyphenate_checkbox.setCheckState(False)
+
+    def hyphenate_checkbox_clicked(self, checked):
+        enable_hyphenation_fields = checked or self.hyphenate_checkbox.isChecked()
+        self.toggle_hyphenation_fields(enable_hyphenation_fields)
+        if self.disable_hyphenation_checkbox.isChecked() and checked:
+            self.disable_hyphenation_checkbox.setCheckState(False)
+
+    def toggle_hyphenation_fields(self, checked):
+        self.opt_kepub_hyphenate_chars_label.setEnabled(checked)
+        self.opt_kepub_hyphenate_chars.setEnabled(checked)
+        self.opt_kepub_hyphenate_chars_before_label.setEnabled(checked)
+        self.opt_kepub_hyphenate_chars_before.setEnabled(checked)
+        self.opt_kepub_hyphenate_chars_after_label.setEnabled(checked)
+        self.opt_kepub_hyphenate_chars_after.setEnabled(checked)
+        self.opt_kepub_hyphenate_limit_lines_label.setEnabled(checked)
+        self.opt_kepub_hyphenate_limit_lines.setEnabled(checked)
 
     @property
     def hyphenate(self):
@@ -341,24 +503,9 @@ class ExtendedGroupBox(DeviceOptionsGroupBox):
         return self.smarten_punctuation_checkbox.isChecked()
 
     @property
-    def clean_markup(self):
-        """Determine if additional markup cleanup will be done."""
-        return self.clean_markup_checkbox.isChecked()
-
-    @property
-    def full_page_numbers(self):
-        """Determine if full-book page numbers will be displayed."""
-        return self.full_page_numbers_checkbox.isChecked()
-
-    @property
     def disable_hyphenation(self):
         """Determine if hyphenation should be disabled."""
         return self.disable_hyphenation_checkbox.isChecked()
-
-    @property
-    def file_copy_dir(self):
-        """Determine where to copy converted KePub books to."""
-        return self.file_copy_dir_edit.text().strip()
 
     @property
     def hyphenate_chars(self):
@@ -375,3 +522,4 @@ class ExtendedGroupBox(DeviceOptionsGroupBox):
     @property
     def hyphenate_limit_lines(self):
         return self.opt_kepub_hyphenate_limit_lines.value()
+


### PR DESCRIPTION
# Pull Request: Add optional template to kepubify only some books.

## Description of change

The current driver is an all-or-nothing affair. Either it will transform all epubs to kepubs, or none. This has meant I have swapped between the built-in KoboTouch driver and the extended driver depending on the books I am reading and transferring to the device. I wanted a way to specify books to be kepubified.

This adds an template to the configuration for whether to kepubify or not. If the template option is enabled, if the template returns a non-empty result for a book, the book will be transformed and sent as a kepub. If the template returns nothing or an empty string, it will be sent as an epub. The default is not to do this and the template is disabled, This means the function is unchanged from before.

While doing this, I redid the configuration. The options are now laid out in three group boxes. The main group has a check-box to enable the kepubification options. Options that are interrelated are enabled as the checkboxes are checked or unchecked.

A beta with these changes in them has been posted on MobileRead in https://www.mobileread.com/forums/showthread.php?p=4199488#post4199488 for a while.