### PR TITLE
Avoid trailing whitespace in kobo spans

### DIFF
--- a/container.py
+++ b/container.py
@@ -610,7 +610,7 @@ class KEPubContainer(EpubContainer):
             node[-1].tail = groups[0]
 
         # append each sentence in its own span
-        segment_counter = 1 
+        segment_counter = 1
         for g, ws in zip(groups[1::2], groups[2::2]):
             span = etree.Element(
                 f"{{{XHTML_NAMESPACE}}}span",
@@ -624,4 +624,4 @@ class KEPubContainer(EpubContainer):
             node.append(span)
             segment_counter += 1
 
-        return len(groups) > 1 # Return true if any spans were added.
+        return len(groups) > 1  # Return true if any spans were added.

--- a/container.py
+++ b/container.py
@@ -87,7 +87,7 @@ ELLIPSIS_RE = re.compile(r"(?u)(?<=\w)\s?(\.\s+?){2}\.", re.UNICODE | re.MULTILI
 MS_CRUFT_RE_1 = re.compile(r"<o:p>\s*</o:p>", re.UNICODE | re.MULTILINE)
 MS_CRUFT_RE_2 = re.compile(r"(?i)</?st1:\w+>", re.UNICODE | re.MULTILINE)
 TEXT_SPLIT_RE = re.compile(
-    r'(\s*.*?[\.\!\?\:][\'"\u201c\u201d\u2018\u2019\u2026]?)(?=\s)',
+    r'(\s*.*?(?:[\.\!\?\:][\'"\u201c\u201d\u2018\u2019\u2026]?|\S(?=\s*$)))(?=\s)',
     re.UNICODE | re.MULTILINE,
 )
 

--- a/container.py
+++ b/container.py
@@ -87,7 +87,7 @@ ELLIPSIS_RE = re.compile(r"(?u)(?<=\w)\s?(\.\s+?){2}\.", re.UNICODE | re.MULTILI
 MS_CRUFT_RE_1 = re.compile(r"<o:p>\s*</o:p>", re.UNICODE | re.MULTILINE)
 MS_CRUFT_RE_2 = re.compile(r"(?i)</?st1:\w+>", re.UNICODE | re.MULTILINE)
 TEXT_SPLIT_RE = re.compile(
-    r'(\s*.*?[\.\!\?\:][\'"\u201c\u201d\u2018\u2019\u2026]?\s*)',
+    r'(\s*.*?[\.\!\?\:][\'"\u201c\u201d\u2018\u2019\u2026]?)(?=\s)',
     re.UNICODE | re.MULTILINE,
 )
 
@@ -616,9 +616,6 @@ class KEPubContainer(EpubContainer):
         # remove empty strings resulting from split()
         groups = [g for g in groups if g != ""]
 
-        # TODO: To match Kobo KePubs, the trailing whitespace needs to
-        # be prepended to the next group. Probably equivalent to make
-        # sure the space stays in the span at the end.
         # add each sentence in its own span
         segment_counter = 1
         for g in groups:

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -278,10 +278,10 @@ class TestContainer(TestAssertions):
             self.assertEqual(len(node.getchildren()), number_of_sentences)
 
         for span in node.getchildren():
-            # spans should not end in whitespace (PR#191)
-            self.assertFalse(re.match(r'\s', span.tail[-1]))
+            # spans should not end in whitespace (PR#191), and be nonempty
+            self.assertFalse(re.match(r'\s', span.text[-1]))
             # tail of span should *only* be whitespace
-            self.assertTrue(re.match(r'\s*', span.tail[-1] or ''))
+            self.assertTrue(re.match(r'\s*', span.tail or ''))
 
             # attrib is technically of type lxml.etree._Attrib, but functionally
             # it's a dict. Cast it here to make assertDictEqual() happy.
@@ -360,7 +360,7 @@ class TestContainer(TestAssertions):
 
         pre_span = self.container.parsed(container_name)
         text_chunks = [
-            g.lstrip("\n\t")
+            g
             for g in pre_span.xpath(
                 "//xhtml:p//text()", namespaces={"xhtml": container.XHTML_NAMESPACE}
             )
@@ -370,7 +370,7 @@ class TestContainer(TestAssertions):
 
         post_span = self.container.parsed(container_name)
         post_text_chunks = [
-            g.lstrip("\n\t")
+            g
             for g in post_span.xpath(
                 "//xhtml:p//text()", namespaces={"xhtml": container.XHTML_NAMESPACE}
             )

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -89,7 +89,9 @@ class TestContainer(TestAssertions):
         self.assertIn(self.container.mime_map[container_name], container.HTML_MIMETYPES)
         self.assertIn("content.opf", self.container.dirtied)
 
-    def __run_added_test(self, expect_changed, added_func):  # type: (bool, Callable) -> None
+    def __run_added_test(
+        self, expect_changed, added_func
+    ):  # type: (bool, Callable) -> None
         if expect_changed:
             source_file = self.files["test_without_spans_with_comments"]
         else:

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -261,16 +261,16 @@ class TestContainer(TestAssertions):
             )
         )
 
-    def __run_single_node_test(self, sentence, text_only=False, number_of_sentences=None):
+    def __run_single_node_test(self, text, text_only=False, number_of_sentences=None):
         self.container.paragraph_counter = defaultdict(lambda: 1)
         node = etree.Element(f"{{{container.XHTML_NAMESPACE}}}p")
 
         if text_only:
             self.assertTrue(
-                self.container._append_kobo_spans_from_text(node, sentence, "test")
+                self.container._append_kobo_spans_from_text(node, text, "test")
             )
         else:
-            node.text = sentence
+            node.text = text
             node = self.container._add_kobo_spans_to_node(node, "test")
 
         # check number of sentences


### PR DESCRIPTION
# Implement long overdue TODO

## Description of change

This seems like a small change but has huge implications for the way text is rendered with optimizeLegibilty and geometricPrecision. Really all it does is move the trailing whitespace to the front of the next group, just like the TODO note suggested ought to be done.

I'm guessing at the exact mechanism, but for *unclear* reasons whatever justification program Kobo method uses it apparently does not expand or contract the last space in a kobo span. (unless using optimizeSpeed, maybe?) This can causes weird looking text, and in the worst case may even expand the space between letters just to stretch the text far enough. If this is correct it would fit the behaviour [observed by jackie_w](https://www.mobileread.com/forums/showpost.php?p=3812607&postcount=60) on the mobileRead forums 

This change may create a few pure-whitespace kobo spans when a sentence has some trailing whitespace, which I think could be ignored. 

## Test results

This seems to fix most issues with optimizeLegibilty. I'm still testing but the improvements I'm seeing are substantial enough that I think it might be best if other people try this out as well. Even if we can't fix everything it improves things *a lot*.

Only niggle is that the regexp only works for proper sentences, there are still a couple of issues with things like *emphasis* where a span might end up with trailing whitespace. These occur when the text ends in whitespace mid sentence.